### PR TITLE
Readability Improvements for qualifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 /.idea/
 /*.iml
 target/
+
+.classpath
+.project
+.settings/

--- a/src/main/java/com/jamesward/osgiversion/OSGiVersionMojo.java
+++ b/src/main/java/com/jamesward/osgiversion/OSGiVersionMojo.java
@@ -87,6 +87,11 @@ public class OSGiVersionMojo extends AbstractMojo {
                     throw new MalformedVersionException(mvnVersion);
             }
         }
+        
+        if(bndVersionSegments[3].startsWith("-")) {
+        	// remove leading dash from qualifier for readability
+        	bndVersionSegments[3] = bndVersionSegments[3].replaceFirst("-", "");
+        }
 
         return toVersionString(bndVersionSegments);
     }

--- a/src/test/java/com/jamesward/osgiversion/UnsnapshotMojoTest.java
+++ b/src/test/java/com/jamesward/osgiversion/UnsnapshotMojoTest.java
@@ -29,9 +29,9 @@ public class UnsnapshotMojoTest extends AbstractMojoTestCase {
             osgiVersionMojo.calculateVersion("");
         } catch (OSGiVersionMojo.MalformedVersionException ignored) { }
 
-        assertEquals("1.2.3.beta1.2", osgiVersionMojo.calculateVersion("1.2.3-beta1-2"));
-        assertEquals("1.2.test", osgiVersionMojo.calculateVersion("1.2-test"));
-        assertEquals("1.2.SNAPSHOT", osgiVersionMojo.calculateVersion("1.2-SNAPSHOT"));
+        assertEquals("1.2.3.beta1-2", osgiVersionMojo.calculateVersion("1.2.3-beta1-2"));
+        assertEquals("1.2.0.test", osgiVersionMojo.calculateVersion("1.2-test"));
+        assertEquals("1.2.0.SNAPSHOT", osgiVersionMojo.calculateVersion("1.2-SNAPSHOT"));
     }
 
     public void testPlugin() throws Exception {


### PR DESCRIPTION
I added the deletion of leading dashes for the qualifier as discussed.
Additionally, I modified the tests so they make the right assumptions. The OSGi versions will always have four segments, although the maven version might only have 2/3, e.g., 
Maven version: 1.2-beta-1
OSGi version: 1.2.0.beta-1