### PR TITLE
Create whole manifest instead of only osgi version

### DIFF
--- a/src/test/java/com/jamesward/osgiversion/ProjectStub.java
+++ b/src/test/java/com/jamesward/osgiversion/ProjectStub.java
@@ -24,5 +24,14 @@ public class ProjectStub extends MavenProjectStub {
         
         setDependencies(dependencies);
     }
+    
+    @Override
+    public void setDependencies(List<Dependency> dependencies) {
+    	getModel().setDependencies( dependencies );
+    }
+    
+    public List<Dependency> getDependencies() {
+        return getModel().getDependencies();
+    }
 
 }

--- a/src/test/java/com/jamesward/osgiversion/ProjectStub.java
+++ b/src/test/java/com/jamesward/osgiversion/ProjectStub.java
@@ -1,5 +1,9 @@
 package com.jamesward.osgiversion;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
 
 public class ProjectStub extends MavenProjectStub {
@@ -9,6 +13,16 @@ public class ProjectStub extends MavenProjectStub {
         setArtifactId("bar");
         setVersion("1.2.3-alpha1");
         setName("foobar");
+        
+        Dependency dependency = new Dependency();
+        dependency.setGroupId("foobar");
+        dependency.setArtifactId("barfoo");
+        dependency.setVersion("2.1.4.0");
+        
+        List<Dependency> dependencies = new ArrayList<>();
+        dependencies.add(dependency);
+        
+        setDependencies(dependencies);
     }
 
 }

--- a/src/test/java/com/jamesward/osgiversion/UnsnapshotMojoTest.java
+++ b/src/test/java/com/jamesward/osgiversion/UnsnapshotMojoTest.java
@@ -43,8 +43,18 @@ public class UnsnapshotMojoTest extends AbstractMojoTestCase {
         assertNotNull(mojo);
 
         mojo.execute();
+       
+        String expected = 
+        		"Bundle-Version: 1.2.3.alpha-1\n"
+        	   + "Bundle-Description: \n"
+        	   + "-resourceonly:true\n"
+        	   + "WebJars-Resource:\\\n"
+        	   + "/META-INF/resources/webjars/bar/1.2.3-alpha-1,\\\n"
+        	   + "/webjars-requirejs.js\n"
+        	   + "Provide-Capability: foo;bar:List<String>=1.2.3.alpha-1\n"
+        	   + "Require-Capability: foobar;filter:=\"(barfoo=2.1.4.0)";
 
-        assertEquals("1.2.3.alpha1", mojo.project.getModel().getProperties().getProperty(OSGiVersionMojo.VERSION_OSGI));
+        assertEquals(expected, mojo.project.getModel().getProperties().getProperty(OSGiVersionMojo.MANIFEST_OSGI));
     }
 
 }

--- a/src/test/java/com/jamesward/osgiversion/UnsnapshotMojoTest.java
+++ b/src/test/java/com/jamesward/osgiversion/UnsnapshotMojoTest.java
@@ -3,6 +3,7 @@ package com.jamesward.osgiversion;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 
 import java.io.File;
+import java.util.concurrent.SynchronousQueue;
 
 public class UnsnapshotMojoTest extends AbstractMojoTestCase {
 
@@ -43,16 +44,16 @@ public class UnsnapshotMojoTest extends AbstractMojoTestCase {
         assertNotNull(mojo);
 
         mojo.execute();
-       
+        
         String expected = 
-        		"Bundle-Version: 1.2.3.alpha-1\n"
-        	   + "Bundle-Description: \n"
-        	   + "-resourceonly:true\n"
-        	   + "WebJars-Resource:\\\n"
-        	   + "/META-INF/resources/webjars/bar/1.2.3-alpha-1,\\\n"
-        	   + "/webjars-requirejs.js\n"
-        	   + "Provide-Capability: foo;bar:List<String>=1.2.3.alpha-1\n"
-        	   + "Require-Capability: foobar;filter:=\"(barfoo=2.1.4.0)\"";
+        		"Bundle-SymbolicName: foo.bar\n" + 
+        		"Bundle-Version: 1.2.3.alpha1\n" + 
+        		"-resourceonly:true\n" + 
+        		"WebJars-Resource:\\\n" + 
+        		"/META-INF/resources/webjars/bar/1.2.3.alpha1,\\\n" + 
+        		"/webjars-requirejs.js\n" + 
+        		"Provide-Capability: org.webjars.osgi.deps;groupId:List<String>=foo,artifactId:List<String>=bar,version:List<String>=1.2.3.alpha1\n" + 
+        		"Require-Capability: org.webjars.osgi.deps;filter:=\"(&(groupId=foobar)(artifactId=barfoo)(version=2.1.4.0))";
 
         assertEquals(expected, mojo.project.getModel().getProperties().getProperty(OSGiVersionMojo.MANIFEST_OSGI));
     }

--- a/src/test/java/com/jamesward/osgiversion/UnsnapshotMojoTest.java
+++ b/src/test/java/com/jamesward/osgiversion/UnsnapshotMojoTest.java
@@ -52,7 +52,7 @@ public class UnsnapshotMojoTest extends AbstractMojoTestCase {
         	   + "/META-INF/resources/webjars/bar/1.2.3-alpha-1,\\\n"
         	   + "/webjars-requirejs.js\n"
         	   + "Provide-Capability: foo;bar:List<String>=1.2.3.alpha-1\n"
-        	   + "Require-Capability: foobar;filter:=\"(barfoo=2.1.4.0)";
+        	   + "Require-Capability: foobar;filter:=\"(barfoo=2.1.4.0)\"";
 
         assertEquals(expected, mojo.project.getModel().getProperties().getProperty(OSGiVersionMojo.MANIFEST_OSGI));
     }


### PR DESCRIPTION
As mentioned in #2  it is probably more sensible to create the whole osgi manifest information within a plugin.
I've added this functionality and cleaned up the code a little bit.

The plugin test ist currently failing, but I don't know why (don't know enough about maven). Maybe you can have a look at this?

If this plugins works as intended then the only thing to add to the POM is

```
<plugin>
	<groupId>biz.aQute.bnd</groupId>
	<artifactId>bnd-maven-plugin</artifactId>
	<configuration>
	    <bnd>
		<![CDATA[
			${manifest.osgi}
		]]>
	   </bnd>
	</configuration>
	<executions>
		<execution>
			<goals>
				<goal>bnd-process</goal>
			</goals>
		</execution>
	</executions>
</plugin>
```